### PR TITLE
use `RefCell` to pass immutable `Warrior` to player

### DIFF
--- a/src/engine/systems/player.rs
+++ b/src/engine/systems/player.rs
@@ -99,7 +99,7 @@ impl<'a> System<'a> for PlayerSystem {
             Direction::Forward => (east, west),
             Direction::Backward => (west, east),
         };
-        let mut warrior = Warrior::new(
+        let warrior = Warrior::new(
             self.floor.level,
             // `Vec<(i32, Tile)>` -> `Vec<Tile>`
             ahead.clone().into_iter().map(|(_, t)| t).collect(),
@@ -108,7 +108,7 @@ impl<'a> System<'a> for PlayerSystem {
             health,
             facing,
         );
-        self.player.play_turn(&mut warrior);
+        self.player.play_turn(&warrior);
 
         if let Some(action) = warrior.action() {
             match action {

--- a/src/player.rs
+++ b/src/player.rs
@@ -9,5 +9,5 @@ pub trait Player: Send + Sync {
     /// This method is called by the game engine repeatedly, once per turn.
     /// See [`Warrior`](crate::warrior::Warrior) to see which actions you
     /// can instruct the Warrior to take.
-    fn play_turn(&mut self, warrior: &mut Warrior);
+    fn play_turn(&mut self, warrior: &Warrior);
 }

--- a/src/warrior.rs
+++ b/src/warrior.rs
@@ -4,6 +4,7 @@ use crate::{
     actions::{Action, Direction},
     floor::Tile,
 };
+use std::cell::RefCell;
 
 /// An interface the player can interact with to control the Warrior in the
 /// game. An instance is passed to [`Player`](crate::player::Player) via the
@@ -17,7 +18,7 @@ pub struct Warrior {
     behind: Vec<Tile>,
     health: i32,
     facing: Direction,
-    action: Option<Action>,
+    action: RefCell<Option<Action>>,
 }
 
 impl Warrior {
@@ -34,21 +35,21 @@ impl Warrior {
             behind,
             health,
             facing,
-            action: None,
+            action: RefCell::new(None),
         }
     }
 
     /// Walk forward one tile.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is available at **Level 1**.
-    pub fn walk(&mut self) {
+    pub fn walk(&self) {
         self.perform_walk(Direction::Forward);
     }
 
     /// Walk one tile toward specified `direction`.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 6**.
-    pub fn walk_toward(&mut self, direction: Direction) {
+    pub fn walk_toward(&self, direction: Direction) {
         if self.level < 6 {
             panic!("You have not yet learned `walk_toward`! Perhaps you meant `walk`?")
         }
@@ -56,7 +57,7 @@ impl Warrior {
     }
 
     // private helper for `walk` and `walk_toward`
-    fn perform_walk(&mut self, direction: Direction) {
+    fn perform_walk(&self, direction: Direction) {
         self.perform(Action::Walk(direction));
     }
 
@@ -120,7 +121,7 @@ impl Warrior {
     /// Attempt to attack an enemy in the tile in front of the Warrior.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 2**.
-    pub fn attack(&mut self) {
+    pub fn attack(&self) {
         if self.level < 2 {
             panic!("You have not yet learned `attack`!");
         }
@@ -130,7 +131,7 @@ impl Warrior {
     /// Attempt to attack an enemy one tile away in specified `direction`.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 6**.
-    pub fn attack_toward(&mut self, direction: Direction) {
+    pub fn attack_toward(&self, direction: Direction) {
         if self.level < 6 {
             panic!("You have not yet learned `attack_toward`! Perhaps you meant `attack`?")
         }
@@ -138,7 +139,7 @@ impl Warrior {
     }
 
     // private helper for `attack` and `attack_toward`
-    fn perform_attack(&mut self, direction: Direction) {
+    fn perform_attack(&self, direction: Direction) {
         self.perform(Action::Attack(direction));
     }
 
@@ -154,7 +155,7 @@ impl Warrior {
     /// Rest and regain 10% of the Warrior's HP.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 3**.
-    pub fn rest(&mut self) {
+    pub fn rest(&self) {
         if self.level < 3 {
             panic!("You have not yet learned `rest`!");
         }
@@ -164,7 +165,7 @@ impl Warrior {
     /// Attempt to rescue a Captive in front of the Warrior.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 5**.
-    pub fn rescue(&mut self) {
+    pub fn rescue(&self) {
         if self.level < 5 {
             panic!("You have not yet learned `rescue`!");
         }
@@ -174,7 +175,7 @@ impl Warrior {
     /// Attempt to rescue a Captive one tile away in specified `direction`.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 6**.
-    pub fn rescue_toward(&mut self, direction: Direction) {
+    pub fn rescue_toward(&self, direction: Direction) {
         if self.level < 6 {
             panic!("You have not yet learned `rescue_toward`! Perhaps you meant `rescue`?")
         }
@@ -182,14 +183,14 @@ impl Warrior {
     }
 
     // private helper for `rescue` and `rescue_toward`
-    fn perform_rescue(&mut self, direction: Direction) {
+    fn perform_rescue(&self, direction: Direction) {
         self.perform(Action::Rescue(direction));
     }
 
     /// Rotate 180 degrees.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 7**.
-    pub fn pivot(&mut self) {
+    pub fn pivot(&self) {
         if self.level < 7 {
             panic!("You have not yet learned `pivot`!")
         }
@@ -203,7 +204,7 @@ impl Warrior {
     /// Fire an arrow up to three tiles in front of the Warrior.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 8**.
-    pub fn shoot(&mut self) {
+    pub fn shoot(&self) {
         if self.level < 8 {
             panic!("You have not yet learned `shoot`!")
         }
@@ -213,7 +214,7 @@ impl Warrior {
     /// Fire an arrow up to three tiles toward specified `direction`.
     /// This is an [`Action`](crate::actions::Action).
     /// This ability is unlocked at **Level 8**.
-    pub fn shoot_toward(&mut self, direction: Direction) {
+    pub fn shoot_toward(&self, direction: Direction) {
         if self.level < 8 {
             panic!("You have not yet learned `shoot_toward`!")
         }
@@ -223,15 +224,15 @@ impl Warrior {
     /// Some [`Action`](crate::actions::Action) the Warrior has performed;
     /// None if no action has been performed.
     pub fn action(&self) -> Option<Action> {
-        self.action
+        *self.action.borrow()
     }
 
-    fn perform(&mut self, action: Action) {
-        if self.action.is_some() {
+    fn perform(&self, action: Action) {
+        if self.action.borrow().is_some() {
             println!("Warrior already performed action!");
             return;
         }
 
-        self.action = Some(action);
+        *self.action.borrow_mut() = Some(action);
     }
 }

--- a/tests/warrior_tests.rs
+++ b/tests/warrior_tests.rs
@@ -4,14 +4,14 @@ use rust_warrior::{actions::Action, Direction, Tile, UnitType, Warrior};
 
 #[test]
 fn test_walk() {
-    let mut warrior = warrior_at_level(1);
+    let warrior = warrior_at_level(1);
     warrior.walk();
     assert_eq!(warrior.action(), Some(Action::Walk(Direction::Forward)));
 }
 
 #[test]
 fn test_attack() {
-    let mut warrior = warrior_at_level(2);
+    let warrior = warrior_at_level(2);
     warrior.attack();
     assert_eq!(warrior.action(), Some(Action::Attack(Direction::Forward)));
 }
@@ -19,13 +19,13 @@ fn test_attack() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_attack_not_unlocked() {
-    let mut warrior = warrior_at_level(1);
+    let warrior = warrior_at_level(1);
     warrior.attack();
 }
 
 #[test]
 fn test_rest() {
-    let mut warrior = warrior_at_level(3);
+    let warrior = warrior_at_level(3);
     warrior.rest();
     assert_eq!(warrior.action(), Some(Action::Rest));
 }
@@ -33,13 +33,13 @@ fn test_rest() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_rest_not_unlocked() {
-    let mut warrior = warrior_at_level(2);
+    let warrior = warrior_at_level(2);
     warrior.rest();
 }
 
 #[test]
 fn test_rescue() {
-    let mut warrior = warrior_at_level(5);
+    let warrior = warrior_at_level(5);
     warrior.rescue();
     assert_eq!(warrior.action(), Some(Action::Rescue(Direction::Forward)));
 }
@@ -47,13 +47,13 @@ fn test_rescue() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_rescue_not_unlocked() {
-    let mut warrior = warrior_at_level(4);
+    let warrior = warrior_at_level(4);
     warrior.rescue();
 }
 
 #[test]
 fn test_pivot() {
-    let mut warrior = warrior_at_level(7);
+    let warrior = warrior_at_level(7);
     warrior.pivot();
     assert_eq!(warrior.action(), Some(Action::Pivot(Direction::Backward)));
 }
@@ -61,13 +61,13 @@ fn test_pivot() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_pivot_not_unlocked() {
-    let mut warrior = warrior_at_level(6);
+    let warrior = warrior_at_level(6);
     warrior.pivot();
 }
 
 #[test]
 fn test_shoot() {
-    let mut warrior = warrior_at_level(8);
+    let warrior = warrior_at_level(8);
     warrior.shoot();
     assert_eq!(warrior.action(), Some(Action::Shoot(Direction::Forward)));
 }
@@ -75,7 +75,7 @@ fn test_shoot() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_shoot_not_unlocked() {
-    let mut warrior = warrior_at_level(7);
+    let warrior = warrior_at_level(7);
     warrior.shoot();
 }
 
@@ -83,7 +83,7 @@ fn test_shoot_not_unlocked() {
 
 #[test]
 fn test_walk_backward() {
-    let mut warrior = warrior_at_level(6);
+    let warrior = warrior_at_level(6);
     warrior.walk_toward(Direction::Backward);
     assert_eq!(warrior.action(), Some(Action::Walk(Direction::Backward)));
 }
@@ -91,13 +91,13 @@ fn test_walk_backward() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_walk_backward_not_unlocked() {
-    let mut warrior = warrior_at_level(5);
+    let warrior = warrior_at_level(5);
     warrior.walk_toward(Direction::Backward);
 }
 
 #[test]
 fn test_attack_backward() {
-    let mut warrior = warrior_at_level(6);
+    let warrior = warrior_at_level(6);
     warrior.attack_toward(Direction::Backward);
     assert_eq!(warrior.action(), Some(Action::Attack(Direction::Backward)));
 }
@@ -105,13 +105,13 @@ fn test_attack_backward() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_attack_backward_not_unlocked() {
-    let mut warrior = warrior_at_level(5);
+    let warrior = warrior_at_level(5);
     warrior.attack_toward(Direction::Backward);
 }
 
 #[test]
 fn test_rescue_backward() {
-    let mut warrior = warrior_at_level(6);
+    let warrior = warrior_at_level(6);
     warrior.rescue_toward(Direction::Backward);
     assert_eq!(warrior.action(), Some(Action::Rescue(Direction::Backward)));
 }
@@ -119,13 +119,13 @@ fn test_rescue_backward() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_rescue_backward_not_unlocked() {
-    let mut warrior = warrior_at_level(5);
+    let warrior = warrior_at_level(5);
     warrior.rescue_toward(Direction::Backward);
 }
 
 #[test]
 fn test_pivot_backward() {
-    let mut warrior = warrior_facing_backward(7);
+    let warrior = warrior_facing_backward(7);
     warrior.pivot();
     assert_eq!(warrior.action(), Some(Action::Pivot(Direction::Forward)));
 }
@@ -133,13 +133,13 @@ fn test_pivot_backward() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_pivot_backward_not_unlocked() {
-    let mut warrior = warrior_at_level(6);
+    let warrior = warrior_at_level(6);
     warrior.pivot();
 }
 
 #[test]
 fn test_shoot_backward() {
-    let mut warrior = warrior_at_level(8);
+    let warrior = warrior_at_level(8);
     warrior.shoot_toward(Direction::Backward);
     assert_eq!(warrior.action(), Some(Action::Shoot(Direction::Backward)));
 }
@@ -147,7 +147,7 @@ fn test_shoot_backward() {
 #[test]
 #[should_panic(expected = "You have not yet learned")]
 fn test_shoot_backward_not_unlocked() {
-    let mut warrior = warrior_at_level(7);
+    let warrior = warrior_at_level(7);
     warrior.shoot_toward(Direction::Backward);
 }
 


### PR DESCRIPTION
The `Warrior` type has seen one overhaul in the past: 1684b9b3bc1c403e5bbd4e6b3367ab8c966b82c1

Even before that, the player needed a `&mut Warrior`.

But the player technically doesn't need to know that a mutation is occurring. They are not explicitly **trying** to change any state. The `action` field is all that's being mutated and it's private.

Is this a valid use of `RefCell`? 🤷‍♂️